### PR TITLE
Determine if docker/podman is used for builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/docker-output
+**/container-output
 .env
 *.idea
 /target

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 
 WORKDIR /geyser-grpc-plugin
 COPY . .
-RUN mkdir -p docker-output
+RUN mkdir -p container-output
 
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
@@ -38,4 +38,4 @@ ENV CI_COMMIT=$ci_commit
 RUN --mount=type=cache,mode=0777,target=/geyser-grpc-plugin/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/git \
-    cargo build --release && cp target/release/libgeyser* ./docker-output
+    cargo build --release && cp target/release/libgeyser* ./container-output

--- a/README.md
+++ b/README.md
@@ -1,38 +1,51 @@
 # geyser-grpc-plugin
+
 A lightweight gRPC service for streaming account and slot updates to subscribers.
 
 ## server
+
 This where the server side logic lives i.e implements the geyser-plugin-interface, wires up the gRPC service, and manages connections.
 Note, what accounts are streamed is decided upon on the initial load of the plugin via a config json file.
 
 ### get_heartbeat_interval
+
 Returns the server's configured heartbeat interval. Clients should consider the server unhealthy if some N consecutive heartbeats are missed.
 
 ### subscribe_account_updates
+
 Subscribe to this endpoint if you're interested in receiving the entire account payload including the account's data bytes.
 
 ### subscribe_partial_account_updates
-This endpoint streams account updates similar to `subscribe_account_updates` except consuming much less bandwidth. You may want to 
+
+This endpoint streams account updates similar to `subscribe_account_updates` except consuming much less bandwidth. You may want to
 use this when you only care to be notified when an account is updated and don't neccessarily care to what the actual state transition was.
 
 ### subscribe_slot_updates
+
 Notifies subscribers of slot state transitions i.e. processed, confirmed, rooted.
 
 ### Necessary Assumptions
+
 The following assumptions __must__ be made:
+
 * Clients may receive data for slots out of order.
 * Clients may receive account updates for a given slot out of order.
 
 ## proto
+
 Contains the protobuf API definitions.
 
 ## client
+
 A simple gRPC client wrapper that Takes an opinionated approach to how account updates shall be consumed.
 Clients using this consumer can expect the following:
+
 1. Account updates will be streamed in monotonically; i.e. updates for older slots are discarded in the event that they were streamed by the server late.
 2. Account updates received out of order will trigger an error.
 
 ## Helper Scripts
+
 For your convenience:
+
 * Run `./s` script to rsync to a server.
-* Run `./f` to build the binary within a Docker container and spit out to a `docker-output` folder.
+* Run `./f` to build the binary within a container and spit out to a `container-output` folder.

--- a/s
+++ b/s
@@ -1,15 +1,15 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 if [ -f .env ]; then
-  export $(cat .env | grep -v '#' | awk '/=/ {print $1}')
+  export "$(< .env grep -v '#' | awk '/=/ {print $1}')"
 else
   echo "Missing .env file"
   exit 0
 fi
 
-echo "Syncing to host: $HOST"
+echo "Syncing to host: ${HOST}"
 
 # sync to build server, ignoring local builds and local/remote dev ledger
-rsync -avh --delete --exclude target --exclude docker-output "$SCRIPT_DIR" "$HOST":~/
+rsync -avh --delete --exclude target --exclude container-output "${SCRIPT_DIR}" "${HOST}":~/

--- a/server/example-config.json
+++ b/server/example-config.json
@@ -1,5 +1,5 @@
 {
-        "libpath": "/path/to/docker-output/libgeyser_grpc_plugin_server.so",
+        "libpath": "/path/to/container-output/libgeyser_grpc_plugin_server.so",
         "accounts_selector" : {
                 "owners": ["*"],
                 "accounts": ["*"]


### PR DESCRIPTION
This adds support for podman without needing to install the docker shim/alias

Changed the folder to "container-output" to be more agnostic

Readme syntax linting cleanups

Minor bash syntax cleanups from shellcheck