### PR TITLE
conditionally pull in jito-solana deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,156 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-attribute-access-control"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "bs58 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-interface"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-state"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-attribute-access-control",
+ "anchor-attribute-account",
+ "anchor-attribute-constant",
+ "anchor-attribute-error",
+ "anchor-attribute-event",
+ "anchor-attribute-interface",
+ "anchor-attribute-program",
+ "anchor-attribute-state",
+ "anchor-derive-accounts",
+ "arrayref",
+ "base64 0.13.0",
+ "bincode",
+ "borsh",
+ "bytemuck",
+ "solana-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.24.2"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anyhow",
+ "bs58 0.3.1",
+ "heck 0.3.3",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +524,12 @@ dependencies = [
 
 [[package]]
 name = "bs58"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+
+[[package]]
+name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
@@ -497,7 +653,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1066,31 +1222,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-sdk",
- "thiserror",
- "tokio",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "geyser-grpc-plugin-client"
-version = "0.1.0"
-source = "git+https://github.com/jito-foundation/geyser-grpc-plugin.git?branch=master#cfcab4d6972c10d366e5a1830080097a4006b307"
-dependencies = [
- "anyhow",
- "async-trait",
- "crossbeam",
- "log",
- "lru",
- "native-tls",
- "prost",
- "prost-types",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-sdk",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
  "tokio",
  "tonic",
@@ -1101,7 +1234,7 @@ dependencies = [
 name = "geyser-grpc-plugin-server"
 version = "0.1.0"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "crossbeam",
  "crossbeam-channel",
  "futures-util",
@@ -1112,12 +1245,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-geyser-plugin-interface",
- "solana-logger",
- "solana-metrics",
- "solana-program",
- "solana-sdk",
- "solana-vote-program",
+ "solana-geyser-plugin-interface 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-geyser-plugin-interface 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-logger 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-metrics 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-vote-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1161,6 +1300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1440,9 +1588,9 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "futures-util",
- "geyser-grpc-plugin-client 0.1.0 (git+https://github.com/jito-foundation/geyser-grpc-plugin.git?branch=master)",
+ "geyser-grpc-plugin-client",
  "prost-types",
- "solana-sdk",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tonic",
  "uuid",
@@ -2015,6 +2163,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,7 +2192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.0",
  "itertools",
  "lazy_static",
  "log",
@@ -2571,16 +2732,40 @@ dependencies = [
  "Inflector",
  "base64 0.13.0",
  "bincode",
- "bs58",
+ "bs58 0.4.0",
  "bv",
  "lazy_static",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-address-lookup-table-program",
- "solana-config-program",
- "solana-sdk",
- "solana-vote-program",
+ "solana-address-lookup-table-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token",
+ "spl-token-2022",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "solana-account-decoder"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "Inflector",
+ "base64 0.13.0",
+ "bincode",
+ "bs58 0.4.0",
+ "bv",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-address-lookup-table-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-config-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-vote-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -2600,11 +2785,31 @@ dependencies = [
  "num-traits",
  "rustc_version",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-program",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-frozen-abi 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-address-lookup-table-program"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "solana-frozen-abi 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-program-runtime 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
 ]
 
@@ -2618,8 +2823,21 @@ dependencies = [
  "chrono",
  "serde",
  "serde_derive",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-program-runtime 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-config-program"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "bincode",
+ "chrono",
+ "serde",
+ "serde_derive",
+ "solana-program-runtime 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
 ]
 
 [[package]]
@@ -2631,7 +2849,7 @@ dependencies = [
  "ahash",
  "blake3",
  "block-buffer 0.9.0",
- "bs58",
+ "bs58 0.4.0",
  "bv",
  "byteorder",
  "cc",
@@ -2651,7 +2869,40 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.6",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-frozen-abi"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
+ "bs58 0.4.0",
+ "bv",
+ "byteorder",
+ "cc",
+ "either",
+ "generic-array",
+ "getrandom 0.1.16",
+ "hashbrown 0.12.3",
+ "im",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "once_cell",
+ "rand_core 0.6.3",
+ "rustc_version",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "subtle",
  "thiserror",
 ]
@@ -2669,14 +2920,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-frozen-abi-macro"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "solana-geyser-plugin-interface"
 version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99f7216b62034ddaa04ea7fae38738d6bd1de2927ca3bdb42fafcd471c9c6751"
 dependencies = [
  "log",
- "solana-sdk",
- "solana-transaction-status",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-transaction-status 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-geyser-plugin-interface"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "log",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-transaction-status 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
 ]
 
@@ -2692,13 +2965,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-logger"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "env_logger",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "solana-measure"
 version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2400d2534a19f7605c5059060edea0499600a223f1a1f6a4b172666c04946a77"
 dependencies = [
  "log",
- "solana-sdk",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-measure"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "log",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
 ]
 
 [[package]]
@@ -2712,7 +3004,20 @@ dependencies = [
  "lazy_static",
  "log",
  "reqwest",
- "solana-sdk",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-metrics"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "crossbeam-channel",
+ "gethostname",
+ "lazy_static",
+ "log",
+ "reqwest",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
 ]
 
 [[package]]
@@ -2727,7 +3032,7 @@ dependencies = [
  "blake3",
  "borsh",
  "borsh-derive",
- "bs58",
+ "bs58 0.4.0",
  "bv",
  "bytemuck",
  "cc",
@@ -2755,9 +3060,57 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.4",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk-macro",
+ "solana-frozen-abi 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tiny-bip39",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-program"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "base64 0.13.0",
+ "bincode",
+ "bitflags",
+ "blake3",
+ "borsh",
+ "borsh-derive",
+ "bs58 0.4.0",
+ "bv",
+ "bytemuck",
+ "cc",
+ "console_error_panic_hook",
+ "console_log",
+ "curve25519-dalek",
+ "getrandom 0.2.5",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "libsecp256k1",
+ "log",
+ "memoffset",
+ "num-derive",
+ "num-traits",
+ "parking_lot 0.12.0",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3 0.10.4",
+ "solana-frozen-abi 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -2783,11 +3136,37 @@ dependencies = [
  "rand 0.7.3",
  "rustc_version",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
+ "solana-frozen-abi 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-program-runtime"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "base64 0.13.0",
+ "bincode",
+ "eager",
+ "enum-iterator",
+ "itertools",
+ "libc",
+ "libloading",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rand 0.7.3",
+ "rustc_version",
+ "serde",
+ "solana-frozen-abi 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-measure 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-metrics 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
 ]
 
@@ -2802,7 +3181,7 @@ dependencies = [
  "bincode",
  "bitflags",
  "borsh",
- "bs58",
+ "bs58 0.4.0",
  "bytemuck",
  "byteorder",
  "chrono",
@@ -2832,13 +3211,65 @@ dependencies = [
  "serde_json",
  "sha2 0.10.6",
  "sha3 0.10.4",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-logger",
- "solana-program",
- "solana-sdk-macro",
+ "solana-frozen-abi 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "uriparse",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "anchor-lang",
+ "assert_matches",
+ "base64 0.13.0",
+ "bincode",
+ "bitflags",
+ "borsh",
+ "bs58 0.4.0",
+ "bytemuck",
+ "byteorder",
+ "chrono",
+ "derivation-path",
+ "digest 0.10.5",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "generic-array",
+ "hmac 0.12.1",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "memmap2",
+ "num-derive",
+ "num-traits",
+ "pbkdf2 0.11.0",
+ "qstring",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3 0.10.4",
+ "solana-frozen-abi 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-logger 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "thiserror",
+ "uriparse",
+ "uuid",
  "wasm-bindgen",
 ]
 
@@ -2848,7 +3279,19 @@ version = "1.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d0acbad862093ea123f3a27364336dcb0c8373522cd6810496a34e932c56c1"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "bs58 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2865,18 +3308,46 @@ dependencies = [
  "base64 0.13.0",
  "bincode",
  "borsh",
- "bs58",
+ "bs58 0.4.0",
  "lazy_static",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-address-lookup-table-program",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
- "solana-vote-program",
+ "solana-account-decoder 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-address-lookup-table-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account",
+ "spl-memo",
+ "spl-token",
+ "spl-token-2022",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-transaction-status"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "Inflector",
+ "base64 0.13.0",
+ "bincode",
+ "borsh",
+ "bs58 0.4.0",
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-address-lookup-table-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-measure 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-metrics 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-vote-program 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
@@ -2897,11 +3368,31 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-metrics",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-frozen-abi 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "1.14.13"
+source = "git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito#66f3d05831dc7daad3293d9da0e519ee782cf593"
+dependencies = [
+ "bincode",
+ "log",
+ "num-derive",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-frozen-abi-macro 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-metrics 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-program-runtime 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
+ "solana-sdk 1.14.13 (git+https://github.com/jito-foundation/jito-solana.git?tag=v1.14.13-jito)",
  "thiserror",
 ]
 
@@ -2929,8 +3420,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program",
- "solana-sdk",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
  "thiserror",
  "zeroize",
@@ -2952,7 +3443,7 @@ dependencies = [
  "borsh",
  "num-derive",
  "num-traits",
- "solana-program",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token",
  "spl-token-2022",
  "thiserror",
@@ -2964,7 +3455,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2978,7 +3469,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -2993,7 +3484,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program",
+ "solana-program 1.14.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-token",
@@ -3405,6 +3896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +4240,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.63.0
+FROM rust:1.64.0
 
 RUN set -x \
  && apt update \
@@ -33,9 +33,15 @@ RUN mkdir -p container-output
 ARG ci_commit
 ENV CI_COMMIT=$ci_commit
 
+ARG features
+
 # Uses docker buildkit to cache the image.
 # /usr/local/cargo/git needed for crossbeam patch
 RUN --mount=type=cache,mode=0777,target=/geyser-grpc-plugin/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/git \
-    cargo build --release && cp target/release/libgeyser* ./container-output
+    if [ -z "$features" ] ; then \
+      cargo build --release && cp target/release/libgeyser* ./container-output; \
+    else \
+      cargo build --release --features "$features" && cp target/release/libgeyser* ./container-output; \
+    fi

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 clap = { version = "4.0.32", features = ["derive", "env"] }
 tonic = { version = "0.8.3", features = ["tls", "tls-roots", "tls-webpki-roots"] }
-geyser-grpc-plugin-client = { git = "https://github.com/jito-foundation/geyser-grpc-plugin.git", branch = "master" }
+geyser-grpc-plugin-client = { path = "../client" }
 tokio = { version = "1.14.1", features = ["full"] }
 futures-util = "0.3.25"
 uuid = { version = "1.2.2", features = ["v4"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,10 +18,17 @@ rand = "0.7"
 serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
+
+jito-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-sdk", optional = true }
+
 solana-sdk = "~1.14"
+
 thiserror = "1.0.37"
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.8.3", features = ["tls"] }
 
 [build-dependencies]
 tonic-build = "0.8.4"
+
+[features]
+jito-solana = ["jito-solana-sdk"]

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,6 +1,12 @@
 pub mod geyser_consumer;
 pub mod types;
 
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_sdk;
+
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_sdk as solana_sdk;
+
 use std::{
     str::FromStr,
     sync::{atomic::AtomicBool, Arc},

--- a/f
+++ b/f
@@ -3,6 +3,9 @@
 # Useful for running on machines that might not have cargo installed but can run docker/podman (Flatcar Linux).
 set -eux
 
+# Comma delimited list of feature flags passed to the geyser-grpc-plugin/server crate e.g. jito-solana.
+FEATURES=${1:-""}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 GIT_SHA="$(git describe --always --dirty)"
@@ -31,7 +34,8 @@ ${CONTAINER_CMD} build \
   --build-arg ci_commit="$GIT_SHA" \
   -t geyser-grpc-plugin \
   -f Dockerfile . \
-  --progress=plain
+  --progress=plain \
+  --build-arg features="$FEATURES"
 
 # Creates a temporary container, copies geyser-grpc-plugin built inside container there and
 # removes the temporary container.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,17 +20,29 @@ prost-types = "0.11.6"
 serde = "1.0.130"
 serde_derive = "1.0.103"
 serde_json = "1.0.67"
+
+jito-solana-geyser-plugin-interface = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-geyser-plugin-interface", optional = true }
+jito-solana-logger = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-logger", optional = true }
+jito-solana-metrics = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-metrics", optional = true }
+jito-solana-program = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-program", optional = true }
+jito-solana-sdk = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-sdk", optional = true }
+jito-solana-vote-program = { git = "https://github.com/jito-foundation/jito-solana.git", tag = "v1.14.13-jito", package = "solana-vote-program", optional = true }
+
 solana-geyser-plugin-interface = "~1.14"
 solana-logger = "~1.14"
 solana-metrics = "~1.14"
 solana-program = "~1.14"
 solana-sdk = "~1.14"
 solana-vote-program = "~1.14"
+
 thiserror = "1.0.37"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = "0.1"
 tonic = "0.8.3"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
+
+[features]
+jito-solana = ["jito-solana-geyser-plugin-interface", "jito-solana-logger", "jito-solana-metrics", "jito-solana-program", "jito-solana-sdk", "jito-solana-vote-program"]
 
 [build-dependencies]
 tonic-build = "0.8.4"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,3 +5,29 @@ pub(crate) mod subscription_stream;
 pub(crate) mod geyser_proto {
     tonic::include_proto!("geyser");
 }
+
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_geyser_plugin_interface;
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_logger;
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_metrics;
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_program;
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_sdk;
+#[cfg(not(feature = "jito-solana"))]
+extern crate solana_vote_program;
+
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_geyser_plugin_interface as solana_geyser_plugin_interface;
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_logger as solana_logger;
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_metrics as solana_metrics;
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_program as solana_program;
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_sdk as solana_sdk;
+#[cfg(feature = "jito-solana")]
+extern crate jito_solana_vote_program as solana_vote_progrma;


### PR DESCRIPTION
Conditionally pull in jito-solana dependencies to avoid dependency hell and submodule setups when running jito-solana rpc