### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,4 @@ For your convenience:
 
 * Run `./s` script to rsync to a server.
 * Run `./f` to build the binary within a container and spit out to a `container-output` folder.
-* Run `./f jito-solana` if you plan on running it with a `jito-solana` node.
   - Be sure to use the same `rustc` version used to build your RPC node as was used to build this.


### PR DESCRIPTION
It seems like running build with the `jito-solana` feature flag is no longer necessary and using it results in error so this line in the readme can be removed.